### PR TITLE
Add press and keyboard ability

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     </style>
   </head>
   <body>
-    <div id="input-box"></div>
+    <div id="input-box" tabindex="0" style="outline: none"></div>
     <script type="module" src="send-input.js"></script>
   </body>
 </html>

--- a/remote_server.py
+++ b/remote_server.py
@@ -17,19 +17,40 @@ PORT = NETWORK.get("remote_port", 9000)
 
 # Set up Windows API
 user32 = ctypes.windll.user32
+MOUSEEVENTF_LEFTDOWN = 0x0002
+MOUSEEVENTF_LEFTUP = 0x0004
+KEYEVENTF_KEYUP = 0x0002
 
 def move_mouse(dx, dy):
     pt = ctypes.wintypes.POINT()
     user32.GetCursorPos(ctypes.byref(pt))
     user32.SetCursorPos(pt.x + int(dx), pt.y + int(dy))
 
+def click_mouse():
+    user32.mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0)
+    user32.mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0)
+
+def press_key(key):
+    vk = user32.VkKeyScanW(ord(key))
+    if vk == -1:
+        print(f"Unsupported key: {key}")
+        return
+    scan = user32.MapVirtualKeyW(vk & 0xFF, 0)
+    user32.keybd_event(vk & 0xFF, scan, 0, 0)
+    user32.keybd_event(vk & 0xFF, scan, KEYEVENTF_KEYUP, 0)
+
 # Input queue
 input_queue = queue.Queue()
 
 def input_worker():
     while True:
-        dx, dy = input_queue.get()
-        move_mouse(dx, dy)
+        item = input_queue.get()
+        if item["type"] == "move":
+            move_mouse(item["dx"], item["dy"])
+        elif item["type"] == "press":
+            click_mouse()
+        elif item["type"] == "key":
+            press_key(item["key"])
         input_queue.task_done()
 
 threading.Thread(target=input_worker, daemon=True).start()
@@ -39,9 +60,14 @@ async def handler(websocket):
     async for msg in websocket:
         try:
             data = json.loads(msg)
-            dx = data.get("dx", 0) * SENSITIVITY
-            dy = data.get("dy", 0) * SENSITIVITY
-            input_queue.put((dx, dy))
+            if data.get("type") == "move":
+                dx = data.get("dx", 0) * SENSITIVITY
+                dy = data.get("dy", 0) * SENSITIVITY
+                input_queue.put({"type": "move", "dx": dx, "dy": dy})
+            elif data.get("type") == "press":
+                input_queue.put({"type": "press"})
+            elif data.get("type") == "key":
+                input_queue.put({"type": "key", "key": data.get("key", "")})
         except json.JSONDecodeError:
             print("Invalid JSON received")
 

--- a/send-input.js
+++ b/send-input.js
@@ -6,6 +6,14 @@ const socket = new WebSocket(
 const inputBox = document.getElementById("input-box");
 const throttleMs = config.settings.throttle_ms;
 
+inputBox.focus();
+
+function sendMessage(data) {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(data));
+  }
+}
+
 let isTouching = false;
 let lastX = null;
 let lastY = null;
@@ -16,6 +24,7 @@ socket.onerror = (err) => console.error("WebSocket error", err);
 
 inputBox.addEventListener("touchstart", (event) => {
   isTouching = true;
+  sendMessage({ type: "press" });
   const touch = event.touches[0];
   lastX = touch.clientX;
   lastY = touch.clientY;
@@ -33,6 +42,10 @@ inputBox.addEventListener("touchcancel", () => {
   lastY = null;
 });
 
+inputBox.addEventListener("keydown", (event) => {
+  sendMessage({ type: "key", key: event.key });
+});
+
 inputBox.addEventListener(
   "touchmove",
   (event) => {
@@ -48,9 +61,7 @@ inputBox.addEventListener(
     lastX = touch.clientX;
     lastY = touch.clientY;
 
-    if (socket.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify({ dx, dy }));
-    }
+    sendMessage({ type: "move", dx, dy });
   },
   { passive: false }
 );


### PR DESCRIPTION
## Summary
- enable mouse click and keyboard input
- send new message types to server
- handle press and key events on server
- make input box focusable for keyboard events

## Testing
- `python -m py_compile frontend_server.py remote_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686234afd8e883308748fea813a4fa39