### PR TITLE
Fix dragging misclick and add keyboard button

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
     </style>
   </head>
   <body>
+    <button id="show-keyboard">Show Keyboard</button>
+    <input
+      id="keyboard-input"
+      type="text"
+      style="position: absolute; opacity: 0; height: 0; width: 0; border: none"
+    />
     <div id="input-box" tabindex="0" style="outline: none"></div>
     <script type="module" src="send-input.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- avoid sending a click when the user drags
- add a hidden text input and a button so phones can open the keyboard

## Testing
- `python3 -m py_compile frontend_server.py remote_server.py`
- `node --check send-input.js`


------
https://chatgpt.com/codex/tasks/task_e_68623602bfd0833084db6bf6c66513b8