### PR TITLE
Add drag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project provides a simple remote control mechanism for a Windows machine us
 - **http_server.py** – serves the web client (`index.html` and `send-input.js`) and a `config.json` file.
 - **send-input.js** – communicates with the remote server from the browser and sends touch or keyboard input.
 - Touch-friendly scroll bar on the right side of the page for sending scroll events.
+- Drag support by holding down on the touch area and moving to simulate a mouse drag.
 
 ## Quick start
 1. Install the Python dependencies:

--- a/src/remote_server.py
+++ b/src/remote_server.py
@@ -70,6 +70,10 @@ def input_worker():
         elif item["type"] == "press":
             user32.mouse_event(0x0002, 0, 0, 0, 0)
             user32.mouse_event(0x0004, 0, 0, 0, 0)
+        elif item["type"] == "down":
+            user32.mouse_event(0x0002, 0, 0, 0, 0)
+        elif item["type"] == "up":
+            user32.mouse_event(0x0004, 0, 0, 0, 0)
         elif item["type"] == "scroll":
             scroll_mouse(item["dy"])
         input_queue.task_done()
@@ -88,6 +92,10 @@ async def handler(websocket):
                 input_queue.put({"type": "key", "key": data.get("key", "")})
             elif data["type"] == "press":
                 input_queue.put({"type": "press"})
+            elif data["type"] == "down":
+                input_queue.put({"type": "down"})
+            elif data["type"] == "up":
+                input_queue.put({"type": "up"})
             elif data["type"] == "scroll":
                 input_queue.put({"type": "scroll", "dy": data.get("dy", 0)})
         except json.JSONDecodeError:

--- a/src/send-input.js
+++ b/src/send-input.js
@@ -24,6 +24,7 @@ let startY = null;
 let lastX = null;
 let lastY = null;
 let moved = false;
+let dragging = false;
 let lastSent = 0;
 let isScrolling = false;
 let scrollLastY = null;
@@ -47,13 +48,16 @@ keyboardInput.addEventListener("blur", () => {
 inputBox.addEventListener("touchstart", (event) => {
   isTouching = true;
   moved = false;
+  dragging = false;
   const touch = event.touches[0];
   startX = lastX = touch.clientX;
   startY = lastY = touch.clientY;
 });
 
 inputBox.addEventListener("touchend", () => {
-  if (!moved) {
+  if (dragging) {
+    sendMessage({ type: "up" });
+  } else if (!moved) {
     sendMessage({ type: "press" });
   }
   isTouching = false;
@@ -62,15 +66,20 @@ inputBox.addEventListener("touchend", () => {
   lastX = null;
   lastY = null;
   moved = false;
+  dragging = false;
 });
 
 inputBox.addEventListener("touchcancel", () => {
+  if (dragging) {
+    sendMessage({ type: "up" });
+  }
   isTouching = false;
   startX = null;
   startY = null;
   lastX = null;
   lastY = null;
   moved = false;
+  dragging = false;
 });
 
 inputBox.addEventListener("keydown", (event) => {
@@ -94,6 +103,10 @@ inputBox.addEventListener(
       Math.abs(touch.clientY - startY) > moveThreshold
     ) {
       moved = true;
+      if (!dragging) {
+        sendMessage({ type: "down" });
+        dragging = true;
+      }
     }
     lastX = touch.clientX;
     lastY = touch.clientY;


### PR DESCRIPTION
## Summary
- add drag mouse events on touch
- allow `remote_server.py` to handle `down` and `up` events
- document drag capability

## Testing
- `python -m py_compile src/remote_server.py src/http_server.py`
- `node -c src/send-input.js`

------
https://chatgpt.com/codex/tasks/task_e_68624c1ac89c8330a03833c61521a058