### PR TITLE
Add IP whitelist for servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ This project provides a simple remote control mechanism for a Windows machine us
 2. Create a `config.json` file. A minimal example:
    ```json
    {
-     "network": {
-       "host": "localhost",
-       "remote_port": 9000,
-       "frontend_port": 8000
-     },
+  "network": {
+    "host": "localhost",
+    "remote_port": 9000,
+    "frontend_port": 8000,
+    "whitelist": ["127.0.0.1"]
+  },
     "settings": {
       "sensitivity": 4,
       "throttle_ms": 16,

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -4,8 +4,20 @@ import os
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
+CONFIG_PATH = os.path.join(SCRIPT_DIR, "config.json")
+with open(CONFIG_PATH, "r") as file:
+    CONFIG = json.load(file)
+    NETWORK = CONFIG["network"]
+    WHITELIST = set(NETWORK.get("whitelist", []))
+
+
 class MyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
+        if WHITELIST and self.client_address[0] not in WHITELIST:
+            self.send_response(403)
+            self.end_headers()
+            self.wfile.write(b"403 Forbidden")
+            return
         try:
             if self.path == "/" or self.path == "/index.html":
                 file_path = os.path.join(SCRIPT_DIR, "index.html")
@@ -45,11 +57,6 @@ class MyHandler(BaseHTTPRequestHandler):
             error_msg = f"500 Internal Server Error: {str(e)}"
             self.wfile.write(error_msg.encode())
             print(f"Error while serving {self.path}: {e}")
-
-CONFIG_PATH = os.path.join(SCRIPT_DIR, "config.json")
-with open(CONFIG_PATH, "r") as file:
-    CONFIG = json.load(file)
-    NETWORK = CONFIG["network"]
 
 server = HTTPServer(("0.0.0.0", NETWORK["frontend_port"]), MyHandler)
 print(f"Serving at http://localhost:{NETWORK['frontend_port']}")

--- a/src/remote_server.py
+++ b/src/remote_server.py
@@ -14,6 +14,7 @@ with open(CONFIG_PATH, "r") as file:
     CONFIG = json.load(file)
     NETWORK = CONFIG["network"]
     SETTINGS = CONFIG["settings"]
+    WHITELIST = set(NETWORK.get("whitelist", []))
 
 SENSITIVITY = SETTINGS.get("sensitivity", 4)
 SCROLL_FACTOR = SETTINGS.get("scroll_factor", 120)
@@ -84,6 +85,11 @@ def input_worker():
 threading.Thread(target=input_worker, daemon=True).start()
 
 async def handler(websocket):
+    ip = websocket.remote_address[0]
+    if WHITELIST and ip not in WHITELIST:
+        print(f"Rejected connection from {ip}")
+        await websocket.close()
+        return
     async for msg in websocket:
         try:
             data = json.loads(msg)


### PR DESCRIPTION
## Summary
- support `whitelist` entries in `config.json`
- reject HTTP requests and websocket connections from non-whitelisted IPs
- document new `whitelist` option in README

## Testing
- `python -m py_compile src/http_server.py src/remote_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68636db543c48330b4fd32c52a571927