### PR TITLE
Log server output to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ This project provides a simple remote control mechanism for a Windows machine us
    ```cmd
    remote.cmd
    ```
-   This launches both `remote_server.py` and `http_server.py`.
+   This runs `run_servers.py` which launches both `remote_server.py` and
+   `http_server.py` and prints their logs in the current console.
    On other platforms run them manually:
    ```bash
    python src/remote_server.py

--- a/remote.cmd
+++ b/remote.cmd
@@ -3,5 +3,4 @@ cd /d "%~dp0"
 
 set PYTHON=venv\Scripts\python.exe
 
-start "" /B %PYTHON% src\http_server.py
-%PYTHON% src\remote_server.py
+%PYTHON% run_servers.py

--- a/run_servers.py
+++ b/run_servers.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import subprocess
+import signal
+import logging
+import threading
+import time
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+
+processes = []
+
+def stream_output(proc: subprocess.Popen, name: str):
+    for line in proc.stdout:
+        logging.info(f"[{name}] {line.rstrip()}")
+
+
+def start_script(name: str, script: str) -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [sys.executable, script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1
+    )
+    threading.Thread(target=stream_output, args=(proc, name), daemon=True).start()
+    logging.info(f"Started {name} (pid {proc.pid})")
+    return proc
+
+
+def stop_processes():
+    for proc in processes:
+        if proc.poll() is None:
+            logging.info(f"Stopping pid {proc.pid}")
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logging.warning(f"Pid {proc.pid} did not terminate, killing")
+                proc.kill()
+
+
+def handle_signal(signum, frame):
+    logging.info("Received shutdown signal")
+    stop_processes()
+    sys.exit(0)
+
+
+def main():
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    http_proc = start_script("HTTP server", os.path.join("src", "http_server.py"))
+    remote_proc = start_script("Remote server", os.path.join("src", "remote_server.py"))
+
+    processes.extend([http_proc, remote_proc])
+
+    try:
+        while True:
+            for proc in processes:
+                ret = proc.poll()
+                if ret is not None:
+                    logging.error(f"Process pid {proc.pid} exited with code {ret}")
+                    handle_signal(None, None)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        handle_signal(None, None)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove file logging from `run_servers.py` and stream child output to stdout
- document that logs now appear in the terminal

## Testing
- `python -m py_compile src/http_server.py src/remote_server.py run_servers.py`


------
https://chatgpt.com/codex/tasks/task_e_6863746ebe208330add3678ea7c9a9b6