### PR TITLE
Streamline remote port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ This project provides a simple remote control mechanism for a Windows machine us
      "sensitivity": 4,
      "throttle_ms": 16,
      "scroll_sensitivity": 1,
-     "press_threshold_ms": 500,
-     "remote_host": "localhost",
-     "remote_port": 9000
+     "press_threshold_ms": 500
    }
    ```
+   The `remote_host` and `remote_port` values are automatically injected from
+   `server_config.json` when the settings are served.
 4. Start the servers (Windows):
    ```cmd
    remote.cmd

--- a/backend/http_server.py
+++ b/backend/http_server.py
@@ -23,6 +23,20 @@ class MyHandler(BaseHTTPRequestHandler):
             return
         try:
             path = self.path.lstrip("/") or "index.html"
+
+            if path == "settings.json":
+                file_path = FRONTEND_DIR / "settings.json"
+                with open(file_path, "r", encoding="utf-8") as f:
+                    settings = json.load(f)
+                settings["remote_host"] = CONFIG.get("host", settings.get("remote_host", "localhost"))
+                settings["remote_port"] = CONFIG.get("remote_port", settings.get("remote_port", 9000))
+                content = json.dumps(settings).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(content)
+                return
+
             file_path = FRONTEND_DIR / path
             if file_path.is_file():
                 content_type, _ = mimetypes.guess_type(str(file_path))

--- a/frontend/settings.json
+++ b/frontend/settings.json
@@ -2,7 +2,5 @@
   "sensitivity": 4,
   "throttle_ms": 16,
   "scroll_sensitivity": 1,
-  "press_threshold_ms": 500,
-  "remote_host": "localhost",
-  "remote_port": 9000
+  "press_threshold_ms": 500
 }


### PR DESCRIPTION
## Summary
- inject `remote_host` and `remote_port` from `server_config.json` when serving `settings.json`
- remove duplicated port and host values from `frontend/settings.json`
- document new behavior in README

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6864aec632a483308870e3d0a8910e46