### PR TITLE
Add TLS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ This project provides a simple remote control mechanism for a Windows machine us
    ```bash
    pip install -r requirements.txt
    ```
-2. Create a `server_config.json` file in the base directory (the same folder as this README) and configure the servers:
+2. Create a `server_config.json` file in the base directory (the same folder as this README) and configure the servers. Set `certfile` and `keyfile` to enable TLS:
    ```json
    {
      "host": "localhost",
      "remote_port": 9000,
      "frontend_port": 8000,
-     "whitelist": ["127.0.0.1"]
+     "whitelist": ["127.0.0.1"],
+     "certfile": "cert.pem",
+     "keyfile": "key.pem"
    }
    ```
 3. Adjust the frontend settings in `frontend/settings.json`:
@@ -35,7 +37,7 @@ This project provides a simple remote control mechanism for a Windows machine us
      "press_threshold_ms": 500
    }
    ```
-   The `host` and `remote_port` values are automatically injected from
+   The `host`, `remote_port`, and TLS settings are automatically injected from
    `server_config.json` when the settings are served.
 4. Start the servers (Windows):
    ```cmd
@@ -47,7 +49,7 @@ This project provides a simple remote control mechanism for a Windows machine us
    python backend/remote_server.py
    python backend/http_server.py
    ```
-5. Open a browser to `http://<host>:<frontend_port>` on your phone or another device to control the machine running the servers.
+5. Open a browser to `http(s)://<host>:<frontend_port>` on your phone or another device to control the machine running the servers.
 
 ## Notes
 

--- a/frontend/js/send-input.js
+++ b/frontend/js/send-input.js
@@ -1,6 +1,7 @@
 const settings = await fetch("/settings.json").then((res) => res.json());
 
-const socket = new WebSocket(`ws://${settings.host}:${settings.remote_port}`);
+const protocol = settings.secure ? "wss" : "ws";
+const socket = new WebSocket(`${protocol}://${settings.host}:${settings.remote_port}`);
 const inputBox = document.getElementById("input-box");
 const scrollBar = document.getElementById("scroll-bar");
 const keyboardInput = document.getElementById("keyboard-input");


### PR DESCRIPTION
## Summary
- enable TLS for remote and HTTP servers when certfile and keyfile are provided
- inject TLS setting into frontend
- use secure WebSocket when TLS is enabled
- document TLS setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655a9427bc8330901bbe4756973025